### PR TITLE
Remove $id

### DIFF
--- a/schemas/system_profile/v1.yaml
+++ b/schemas/system_profile/v1.yaml
@@ -102,7 +102,6 @@ $defs:
         type: string
         example: "ether"
   SystemProfile:
-    $id: SystemProfile
     title: System profile fields
     description: Representation of the system profile fields
     type: object


### PR DESCRIPTION
The $id key is not compatible with OpenAPI. Remove it.

In https://github.com/RedHatInsights/insights-host-inventory/pull/682, an exact copy of this file starts to be used in the OpenAPI specification. Syncing.

Hopefully the _$id_ won’t be necessary to use _jsonschema_ or other libraries directly.