### PR TITLE
Remove unnecessary stuff

### DIFF
--- a/schemas/system_profile/v1.yaml
+++ b/schemas/system_profile/v1.yaml
@@ -116,7 +116,6 @@ $defs:
         maxLength: 18
   SystemProfile:
     description: Representation of the system profile fields
-    type: object
     properties:
       number_of_cpus:
         type: integer

--- a/schemas/system_profile/v1.yaml
+++ b/schemas/system_profile/v1.yaml
@@ -1,7 +1,6 @@
 ---
 $id: system_profile.spec.yaml
 $schema: https://json-schema.org/draft/2019-09/schema#
-$version: 1
 $defs:
   DiskDevice:
     description: Representation of one mounted device

--- a/schemas/system_profile/v1.yaml
+++ b/schemas/system_profile/v1.yaml
@@ -4,7 +4,6 @@ $schema: https://json-schema.org/draft/2019-09/schema#
 $version: 1
 $defs:
   DiskDevice:
-    title: Disk Device
     description: Representation of one mounted device
     properties:
       device:
@@ -37,7 +36,6 @@ $defs:
         type: string
         maxLength: 256
   YumRepo:
-    title: Yum Repository
     description: Representation of one yum repository
     properties:
       id:
@@ -55,7 +53,6 @@ $defs:
         format: uri
         maxLength: 2048
   DnfModule:
-    title: DNF Module
     description: Representation of one DNF module
     properties:
       name:
@@ -65,7 +62,6 @@ $defs:
         type: string
         maxLength: 2048
   InstalledProduct:
-    title: Installed Product
     description: Representation of one installed product
     properties:
       name:
@@ -82,7 +78,6 @@ $defs:
         type: string
         maxLength: 256
   NetworkInterface:
-    title: Network Interface
     description: Representation of one network interface
     properties:
       ipv4_addresses:
@@ -120,7 +115,6 @@ $defs:
         example: "ether"
         maxLength: 18
   SystemProfile:
-    title: System profile fields
     description: Representation of the system profile fields
     type: object
     properties:


### PR DESCRIPTION
- The titles don’t add any value. They just repeat what the names say. Removed.
- Definitions with schemas are objects by default. Use object only for arbitrary dictionaries. (Those are going to be removed anyway.)
- Version is not necessary. For now there is going to be only one canonical schema.

No JIRA ticket. Slightly related to [RHCLOUD-8147](https://projects.engineering.redhat.com/browse/RHCLOUD-8147).