### PR TITLE
Copy string length constraints from Marshmallow

### DIFF
--- a/schemas/system_profile/v1.yaml
+++ b/schemas/system_profile/v1.yaml
@@ -118,8 +118,10 @@ $defs:
         format: int64
       infrastructure_type:
         type: string
+        maxLength: 100
       infrastructure_vendor:
         type: string
+        maxLength: 100
       network_interfaces:
         type: array  # techincally a set, ordering is not important
         items:
@@ -130,42 +132,55 @@ $defs:
           $ref: '#/$defs/DiskDevice'
       bios_vendor:
         type: string
+        maxLength: 100
       bios_version:
         type: string
+        maxLength: 100
       bios_release_date:
         type: string
+        maxLength: 50
       cpu_flags:
         items:
           type: string
+          maxLength: 30
         type: array
       os_release:
         type: string
+        maxLength: 100
       os_kernel_version:
         type: string
+        maxLength: 100
       arch:
         type: string
+        maxLength: 50
       kernel_modules:
         type: array
         items:
           type: string
+          maxLength: 255
       last_boot_time:
         type: string
         format: date-time
+        maxLength: 50
       running_processes:
         type: array  # techincally a set, ordering is not important
         items:
           description: a single running process. This will be truncated to 1000 characters when saved.
           type: string
+          maxLength: 1000
       subscription_status:
         type: string
+        maxLength: 100
       subscription_auto_attach:
         type: string
+        maxLength: 100
       katello_agent_running:
         type: boolean
       satellite_managed:
         type: boolean
       cloud_provider:
         type: string
+        maxLength: 100
       yum_repos:
         type: array  # technically a set, ordering is not important
         items:
@@ -180,24 +195,30 @@ $defs:
           $ref: '#/$defs/InstalledProduct'
       insights_client_version:
         type: string
+        maxLength: 50
       insights_egg_version:
         type: string
+        maxLength: 50
       captured_date:
         type: string
+        maxLength: 32
       installed_packages:
         type: array  # technically a set, ordering is not important
         items:
           description: a NEVRA string for a single installed package
           type: string
           example: "krb5-libs-0:-1.16.1-23.fc29.i686"
+          maxLength: 512
       installed_services:
         type: array
         items:
           type: string
+          maxLength: 512
       enabled_services:
         type: array
         items:
           type: string
+          maxLength: 512
       sap_system:
         type: boolean
         description: Indicates if SAP is installed on the system

--- a/schemas/system_profile/v1.yaml
+++ b/schemas/system_profile/v1.yaml
@@ -10,9 +10,11 @@ $defs:
       device:
         example: "/dev/fdd0"
         type: string
+        maxLength: 2048
       label:
         description: user-defined mount label
         type: string
+        maxLength: 1024
       options:
         description: mount options
         example:
@@ -28,18 +30,22 @@ $defs:
         description: mount point
         example: "/mnt/remote_nfs_shares"
         type: string
+        maxLength: 2048
       type:
         description: mount type
         example: "ext3"
         type: string
+        maxLength: 256
   YumRepo:
     title: Yum Repository
     description: Representation of one yum repository
     properties:
       id:
         type: string
+        maxLength: 256
       name:
         type: string
+        maxLength: 1024
       gpgcheck:
         type: boolean
       enabled:
@@ -47,28 +53,34 @@ $defs:
       baseurl:
         type: string
         format: uri
+        maxLength: 2048
   DnfModule:
     title: DNF Module
     description: Representation of one DNF module
     properties:
       name:
         type: string
+        maxLength: 128
       stream:
         type: string
+        maxLength: 2048
   InstalledProduct:
     title: Installed Product
     description: Representation of one installed product
     properties:
       name:
         type: string
+        maxLength: 512
       id:
         description: the product ID
         example: "71"
         type: string
+        maxLength: 64
       status:
         description: subscription status for product
         example: "Subscribed"
         type: string
+        maxLength: 256
   NetworkInterface:
     title: Network Interface
     description: Representation of one network interface
@@ -90,18 +102,23 @@ $defs:
         description: MAC address (with or without colons)
         example: "00:00:00:00:00:00"
         type: string
+        maxLength: 59
       name:
         description: name of interface
         type: string
         example: eth0
+        minLength: 1
+        maxLength: 50
       state:
         description: interface state (UP, DOWN, UNKNOWN)
         type: string
         example: "UP"
+        maxLength: 25
       type:
         description: interface type (ether, loopback)
         type: string
         example: "ether"
+        maxLength: 18
   SystemProfile:
     title: System profile fields
     description: Representation of the system profile fields


### PR DESCRIPTION
Copied string length constraints from Marshmallow [models](https://github.com/RedHatInsights/insights-host-inventory/blob/4c97acb7cf77d4181db9fbc2a574b4a3759987d2/app/models.py) to the externalized schema. Now the validation rules here match those in Marshmallow.

JIRA ticket [RHCLOUD-7497](https://projects.engineering.redhat.com/browse/RHCLOUD-7497)