### PR TITLE
Add os_release_major, os_release_minor

### DIFF
--- a/schemas/system_profile/v1.yaml
+++ b/schemas/system_profile/v1.yaml
@@ -161,6 +161,12 @@ $defs:
           type: string
           maxLength: 30
         type: array
+      os_release_major:
+        type: int
+        maxLength: 4
+      os_release_minor:
+        type: int
+        maxLength: 4
       os_release:
         type: string
         maxLength: 100


### PR DESCRIPTION
I would like to let reporters start splitting out the os_release string into two
(for now) ints. We can talk about deprecating the old os_release String once we
have report quorum/adoption.