### PR TITLE
Validate against Draft4

### DIFF
--- a/tools/simple-test/tester.py
+++ b/tools/simple-test/tester.py
@@ -2,6 +2,7 @@ from sys import argv
 
 from json import load as json_load
 from jsonschema import validate as jsonschema_validate
+from jsonschema.validators import Draft4Validator
 from yaml import safe_load as yaml_safe_load
 
 spec_path = argv[1]
@@ -12,4 +13,4 @@ with open(sample_path) as sample_data, open(spec_path) as spec_data:
     spec_dict = yaml_safe_load(spec_data)
 
 schema_dict = {**spec_dict, "$ref": "#/$defs/SystemProfile"}
-jsonschema_validate(instance=sample_dict, schema=schema_dict)
+jsonschema_validate(instance=sample_dict, schema=schema_dict, cls=Draft4Validator)


### PR DESCRIPTION
The Host Inventory uses JSONSchema Draft 4 for validation. [[Reference](https://github.com/zalando/connexion/blob/3fecd3e7351bfff330c5421551d8e26f88cbfc28/connexion/decorators/validation.py#L109)] It is the default of the Connexion framework used by the app. Use the same validator here to ensure compatibility.