### PR TITLE
Make tester executable

### DIFF
--- a/tools/simple-test/tester.py
+++ b/tools/simple-test/tester.py
@@ -1,15 +1,28 @@
-from sys import argv
+#!/usr/bin/env python
+
+from argparse import ArgumentParser
 
 from json import load as json_load
 from jsonschema import validate as jsonschema_validate
 from yaml import safe_load as yaml_safe_load
 
-spec_path = argv[1]
-sample_path = argv[2]
 
-with open(sample_path) as sample_data, open(spec_path) as spec_data:
-    sample_dict = json_load(sample_data)
-    spec_dict = yaml_safe_load(spec_data)
+def _parse_args():
+    parser = ArgumentParser()
+    parser.add_argument("spec_path", type=str, help="JSON schema specification path")
+    parser.add_argument("sample_path", type=str, help="JSON document sample path")
+    return parser.parse_args()
 
-schema_dict = {**spec_dict, "$ref": "#/$defs/SystemProfile"}
-jsonschema_validate(instance=sample_dict, schema=schema_dict)
+
+def main(args):
+    with open(args.sample_path) as sample_data, open(args.spec_path) as spec_data:
+        sample_dict = json_load(sample_data)
+        spec_dict = yaml_safe_load(spec_data)
+
+    schema_dict = {**spec_dict, "$ref": "#/$defs/SystemProfile"}
+    jsonschema_validate(instance=sample_dict, schema=schema_dict)
+
+
+if __name__ == "__main__":
+    parsed_args = _parse_args()
+    main(parsed_args)


### PR DESCRIPTION
Turned the JSON Schema tester to a proper standalone script:

- Used argparse to parse command line arguments.
- Added `__name__ == "__main__"` conditional to make it importable.
- Chmodded u+x to make it executable.

_run.sh_ still works without change.

Possible usage:

```bash
$ . tools/simple-test/venv/activate
$ tools/simple-test/tester.py ../../schemas/system_profile/v1.yaml ../../scratch/sample.json
```
