### PR TITLE
Disk device options

### DIFF
--- a/schemas/system_profile/v1.yaml
+++ b/schemas/system_profile/v1.yaml
@@ -2,6 +2,11 @@
 $id: system_profile.spec.yaml
 $schema: https://json-schema.org/draft/2019-09/schema#
 $defs:
+  NestedObject:
+    propertyNames:
+      minLength: 1
+    additionalProperties:
+      "$ref": "#/$defs/NestedObject"
   DiskDevice:
     description: Representation of one mounted device
     properties:
@@ -18,9 +23,7 @@ $defs:
         example:
           uid: "0"
           ro: true
-        type: object
-        propertyNames:
-          minLength: 1
+        "$ref": "#/$defs/NestedObject"
       mount_point:
         description: mount point
         example: "/mnt/remote_nfs_shares"

--- a/schemas/system_profile/v1.yaml
+++ b/schemas/system_profile/v1.yaml
@@ -19,11 +19,8 @@ $defs:
           uid: "0"
           ro: true
         type: object
-        properties:
-          name:
-            type: string
-          value:
-            type: string
+        propertyNames:
+          minLength: 1
       mount_point:
         description: mount point
         example: "/mnt/remote_nfs_shares"

--- a/schemas/system_profile/v1.yaml
+++ b/schemas/system_profile/v1.yaml
@@ -3,6 +3,7 @@ $id: system_profile.spec.yaml
 $schema: https://json-schema.org/draft/2019-09/schema#
 $defs:
   NestedObject:
+    description: An arbitrary object that doesn’t allow empty string keys.
     propertyNames:
       minLength: 1
     additionalProperties:


### PR DESCRIPTION
Added a constraint for _/disk_devices/options_. In Marshmallow we require all keys to be non-empty strings, including those of the nested objects. The new constraint does exactly this.

Examples of invalid payloads:

```json
  "disk_devices": [
    {
      "type": "ext3",
      "label": "home drive",
      "device": "/dev/sdb1",
      "options": {
        "ro": true,
        "uid": "0",
        "": "thou shall not pass"
      },
      "mount_point": "/home"
    }
  ],
```

```json
  "disk_devices": [
    {
      "type": "ext3",
      "label": "home drive",
      "device": "/dev/sdb1",
      "options": {
        "ro": true,
        "uid": "0",
        "nested": {
            "this": "is fine",
            "": "is not"
        }
      },
      "mount_point": "/home"
    }
  ],
```