### PR TITLE
Change schema version to Draft7

### DIFF
--- a/schemas/system_profile/v1.yaml
+++ b/schemas/system_profile/v1.yaml
@@ -1,6 +1,6 @@
 ---
 $id: system_profile.spec.yaml
-$schema: https://json-schema.org/draft/2019-09/schema#
+$schema: http://json-schema.org/draft-07/schema#
 $defs:
   DiskDevice:
     description: Representation of one mounted device


### PR DESCRIPTION
Downgraded the JSON Schema to the Draft 7 version. It is the most recent version supported by _jsonschema 3.2.0_ used by the Inventory. [[Reference](https://github.com/Julian/jsonschema/tree/v3.2.0#features)] This version is automatically determined and used both by the Spectral linter and by the tester script. We need at least version 6 because of the _propertyNames_ support. The same JSON Schema version is going to be used in the Inventory.

To test this:

1. Run the linter
   ```bash
   $ spectral lint schemas/system_profile/v1.yaml`.
   ```
2. See that the correct version has been detected.
    ```
    JSON Schema Draft 7 detected
    ```
3. Create a sample JSON file that is invalid only against Draft 7.
   ```json
   {
     "disk_devices": [
       {
         "options": {
           "": "empty key"
         }
       }
     ]
   }
   ```
4. Run the tester script.
   ```bash
   $ tools/simple-test/run.sh
   ```
5. See that the validation fails.
   ```
   jsonschema.exceptions.ValidationError: '' is too short
   
   Failed validating 'minLength' in schema['properties']['disk_devices']['items']['properties']['options']['propertyNames']:
       {'minLength': 1}
   
   On instance['disk_devices'][0]['options']:
       ''
   ```
6. Temporarily change the schema version to Draft 4.
   ```
   {
     ...
     $schema: http://json-schema.org/draft-04/schema#,
     ...
   }
   ```
7. Run the tester script again.
   ```bash
   $ tools/simple-test/run.sh
   ```
8. See that the validation passes.