### PR TITLE
Fix yum_repos/base_url field name

### DIFF
--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -39,7 +39,7 @@ except:
   'schemas/system_profile/v1.yaml#/$defs/YumRepo/properties/name': ['property-example', 'property-description']
   'schemas/system_profile/v1.yaml#/$defs/YumRepo/properties/gpgcheck': ['property-example', 'property-description']
   'schemas/system_profile/v1.yaml#/$defs/YumRepo/properties/enabled': ['property-example', 'property-description']
-  'schemas/system_profile/v1.yaml#/$defs/YumRepo/properties/baseurl': ['property-example', 'property-description']
+  'schemas/system_profile/v1.yaml#/$defs/YumRepo/properties/base_url': ['property-example', 'property-description']
   'schemas/system_profile/v1.yaml#/$defs/DnfModule/properties/name': ['property-example', 'property-description']
   'schemas/system_profile/v1.yaml#/$defs/DnfModule/properties/stream': ['property-example', 'property-description']
   'schemas/system_profile/v1.yaml#/$defs/InstalledProduct/properties/name': ['property-example', 'property-description']

--- a/schemas/system_profile/v1.yaml
+++ b/schemas/system_profile/v1.yaml
@@ -51,7 +51,7 @@ $defs:
         type: boolean
       enabled:
         type: boolean
-      baseurl:
+      base_url:
         type: string
         format: uri
         maxLength: 2048


### PR DESCRIPTION
By a mistake, the _yum_repos/base_url_ key had a wrong name. @rodrigonull reported this. Unfortunately this even got to the Host Inventory codebase, causing this value not to be stored at all. 😞 A fix for this in the Host Inventory is a part of https://github.com/RedHatInsights/insights-host-inventory/pull/715. Fixing here too for consistency.