### PR TITLE
Add os_vendor enum

### DIFF
--- a/schemas/system_profile/v1.yaml
+++ b/schemas/system_profile/v1.yaml
@@ -165,6 +165,10 @@ $defs:
           type: string
           maxLength: 30
         type: array
+      os_vendor:
+        type: string
+        enum: ["Red Hat", "Cannonical", "Oracle", "CentOS", "Debian"]
+        description: The vendor of the OS/distro
       os_release:
         type: string
         maxLength: 100

--- a/schemas/system_profile/v1.yaml
+++ b/schemas/system_profile/v1.yaml
@@ -167,6 +167,7 @@ $defs:
         type: array
       os_vendor:
         type: string
+        example: "Red Hat"
         enum: ["Red Hat", "Cannonical", "Oracle", "CentOS", "Debian"]
         description: The vendor of the OS/distro
       os_release:


### PR DESCRIPTION
Applications (inventory at least) want to be able to filter out only RHEL like systems.
We don't want to necessarily differentiate between os types (ie RHEL vs RH Desktop Linux etc)...
Or not at the moment at least.

We could still add in the future os_type, os_release, os_flavor etc (or something like those).