### PR TITLE
Include all remaining packages not in installed_packages

### DIFF
--- a/schemas/system_profile/v1.yaml
+++ b/schemas/system_profile/v1.yaml
@@ -263,6 +263,13 @@ $defs:
           example: "krb5-libs-0:-1.16.1-23.fc29.i686"
           type: string
           maxLength: 512
+      installed_packages_delta:
+        type: array  # sorted list, rest of packages not in installed_packages
+        items:
+          description: A NEVRA string for a single installed package
+          example: "krb5-libs-0:-1.16.1-23.fc29.i686"
+          type: string
+          maxLength: 512
       installed_services:
         type: array
         items:


### PR DESCRIPTION
A way to have all packages passed along and not only the max of multi values provided by installed_packages without breaking those dependent on the current implementation of installed_packages.

Dependent on:
https://github.com/RedHatInsights/insights-puptoo/pull/69