### PR TITLE
Fixing NestedObject definition

### DIFF
--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -100,6 +100,7 @@ except:
   'schemas/system_profile/v1.yaml#/$defs/SystemProfile/properties/insights_egg_version': ['property-example', 'property-description']
   'schemas/system_profile/v1.yaml#/$defs/SystemProfile/properties/captured_date': ['property-example', 'property-description']
   'schemas/system_profile/v1.yaml#/$defs/NestedObject': ['property-arbitrary-object-without-keys']
+  'schemas/system_profile/v1.yaml#/$defs/NestedObject/additionalProperties/oneOf/1/not': ['property-arbitrary-object-without-keys']
   'schemas/system_profile/v1.yaml#/$defs/DiskDevice/properties/options': ['property-arbitrary-object-without-keys']
   'schemas/system_profile/v1.yaml#/$defs/NetworkInterface/properties/ipv4_addresses/items': ['property-string-max-length']
   'schemas/system_profile/v1.yaml#/$defs/NetworkInterface/properties/ipv6_addresses/items': ['property-string-max-length']

--- a/schemas/system_profile/v1.yaml
+++ b/schemas/system_profile/v1.yaml
@@ -7,7 +7,10 @@ $defs:
     propertyNames:
       minLength: 1
     additionalProperties:
-      "$ref": "#/$defs/NestedObject"
+      oneOf:
+        - "$ref": "#/$defs/NestedObject"
+        - not:
+            type: object
   DiskDevice:
     description: Representation of one mounted device
     type: object
@@ -25,7 +28,6 @@ $defs:
         example:
           uid: "0"
           ro: true
-        type: object
         "$ref": "#/$defs/NestedObject"
       mount_point:
         description: The mount point

--- a/schemas/system_profile/v1.yaml
+++ b/schemas/system_profile/v1.yaml
@@ -3,6 +3,7 @@ $id: system_profile.spec.yaml
 $schema: http://json-schema.org/draft-07/schema#
 $defs:
   NestedObject:
+    type: object
     description: An arbitrary object that doesn’t allow empty string keys.
     propertyNames:
       minLength: 1

--- a/schemas/system_profile/v1.yaml
+++ b/schemas/system_profile/v1.yaml
@@ -3,7 +3,6 @@ $id: system_profile.spec.yaml
 $schema: http://json-schema.org/draft-07/schema#
 $defs:
   NestedObject:
-    type: object
     description: An arbitrary object that doesn’t allow empty string keys.
     propertyNames:
       minLength: 1
@@ -26,6 +25,7 @@ $defs:
         example:
           uid: "0"
           ro: true
+        type: object
         "$ref": "#/$defs/NestedObject"
       mount_point:
         description: The mount point


### PR DESCRIPTION
I think the current `NestedObject` definition is that all the children of `options` must be objects. For example, a valid request is expected to look like the following: `options: {"uid": {"blah: {"another_one": {}}}}`. 

But, I think what we want `options` to look like is something like this: `options: {"uid":"0","ro":false, "random":{"yep":true}}`.
We can close/update this if this isn't accurate. :+1: 

Corresponding HBI PR: https://github.com/RedHatInsights/insights-host-inventory/pull/771