### PR TITLE
added rhsm_releasever

### DIFF
--- a/schemas/system_profile/v1.yaml
+++ b/schemas/system_profile/v1.yaml
@@ -324,3 +324,12 @@ $defs:
         maxLength: 10
         description: The SELinux mode provided in the config file
         example: 'permissive'
+      rhsm:
+        description: Object for subscription-manager details
+        type: object
+        properties:
+          version:
+            description: System release set by subscription-manager
+            example: "8.1"
+            type: string
+            maxLength: 255


### PR DESCRIPTION
support for subscription-manager release lock

reopening this PR once again as it was incorrecly closed (see #18).

os release and rhsm release are independent values.

you can install e.g. RHEL 8.3 and set RHSM to lock version to 8.2