### PR TITLE
Use x-propertyNames in place of propertyNames

### DIFF
--- a/schemas/system_profile/v1.yaml
+++ b/schemas/system_profile/v1.yaml
@@ -5,7 +5,9 @@ $defs:
   NestedObject:
     type: object
     description: An arbitrary object that doesn’t allow empty string keys.
-    propertyNames:
+    # openapi spec does not support propertyNames, we will use a custom validator
+    # to validate x-propertyNames as propertyNames
+    x-propertyNames:
       minLength: 1
     additionalProperties:
       "$ref": "#/$defs/NestedObject"


### PR DESCRIPTION
OpenApi specification does not support `propertyNames`. Check [here](https://swagger.io/docs/specification/data-models/keywords/).
We will use a custom validator to treat `x-propertyNames` as `propertyNames`.

HBI PR that handles `x-propertyNames`: https://github.com/RedHatInsights/insights-host-inventory/pull/771