### PR TITLE
Relax sap_instance_number to include 98/99

### DIFF
--- a/schemas/system_profile/v1.yaml
+++ b/schemas/system_profile/v1.yaml
@@ -287,10 +287,10 @@ $defs:
           pattern: '^[A-Z][A-Z0-9]{2}$'
       sap_instance_number:
         type: string
-        description: The instance number of the SAP HANA system (a two-digit number between 00 and 97)
+        description: The instance number of the SAP HANA system (a two-digit number between 00 and 99)
         example: '03'
         maxLength: 2
-        pattern: '(?!99)(?!98)^[0-9]{2}$'
+        pattern: '^[0-9]{2}$'
       sap_version:
         type: string
         description: The version of the SAP HANA lifecycle management program


### PR DESCRIPTION
Even though SAP installs cannot have 98 or 99 as their instance number, these are valid coming from diagnostic tools so we need to relax our schema to allow these values.

https://issues.redhat.com/browse/HBISPSC-37