### PR TITLE
Downgrade schema from draft 7 to draft 4

### DIFF
--- a/schemas/system_profile/v1.yaml
+++ b/schemas/system_profile/v1.yaml
@@ -1,6 +1,6 @@
 ---
 $id: system_profile.spec.yaml
-$schema: http://json-schema.org/draft-07/schema#
+$schema: http://json-schema.org/draft-04/schema#
 $defs:
   NestedObject:
     type: object


### PR DESCRIPTION
Trying to use a Draft 7 validator to validate system_profile in HBI is causing us some hurdles as I explained [here](https://github.com/RedHatInsights/insights-host-inventory/pull/771#issuecomment-756366770).
I found the draft 7 version of the schema that lives in this repo to be fully backward compatible with draft 4, and I don't think we will be needing those draft 7 features of the schema here (feel free to disagree). While trying to resolve the discrepancies, we found it to be simpler to use a draft 4 validator instead of a draft 7 one. Therefore, I am opening this PR to downgrade this to draft 4 for the sake of consistency. 

Links:

- [HBI PR](https://github.com/RedHatInsights/insights-host-inventory/pull/771)
- [Draft 4 -> Draft 6 changes](https://json-schema.org/draft-06/json-schema-release-notes.html)
- [Draft 6 -> Draft 7 changes](https://json-schema.org/draft-07/json-schema-release-notes.html)