### PR TITLE
fix: apostrophe in system_profile schema

### DIFF
--- a/schemas/system_profile/v1.yaml
+++ b/schemas/system_profile/v1.yaml
@@ -4,7 +4,7 @@ $schema: http://json-schema.org/draft-04/schema#
 $defs:
   NestedObject:
     type: object
-    description: An arbitrary object that doesn’t allow empty string keys.
+    description: An arbitrary object that does not allow empty string keys.
     # openapi spec does not support propertyNames, we will use a custom validator
     # to validate x-propertyNames as propertyNames
     x-propertyNames:


### PR DESCRIPTION
There is an apostrophe in a description that is throwing off some yaml
safe_load operations. Running into an encoding error.

This should fix that

Signed-off-by: Stephen Adams <tsadams@gmail.com>