### PR TITLE
Add the model name as cpu_model to system profile

### DIFF
--- a/schemas/system_profile/v1.yaml
+++ b/schemas/system_profile/v1.yaml
@@ -139,6 +139,11 @@ $defs:
         pattern: '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
         maxLength: 36
         example: 22cd8e39-13bb-4d02-8316-84b850dc5136
+      cpu_model:
+        description: The cpu model name
+        type: string
+        maxLength: 100
+        example: 'Intel(R) Xeon(R) CPU E5-2690 0 @ 2.90GHz'
       number_of_cpus:
         type: integer
       number_of_sockets:

--- a/tests/utils/invalids.py
+++ b/tests/utils/invalids.py
@@ -49,6 +49,7 @@ INVALID_SYSTEM_PROFILES = (
     {"selinux_current_mode": "random"},
     {"selinux_config_file": "random"},
     {"owner_id": "x"*12},
+    {"cpu_model": "x"*101},
     {"number_of_cpus": "35465"},
     {"number_of_sockets": "35465"},
     {"cores_per_socket": "35465"},

--- a/tests/utils/valids.py
+++ b/tests/utils/valids.py
@@ -47,6 +47,7 @@ VALID_SYSTEM_PROFILES = (
     {"selinux_current_mode": "enforcing"},
     {"selinux_config_file": "permissive"},
     {"owner_id": "22cd8e39-13bb-4d02-8316-84b850dc5136"},
+    {"cpu_model": "Intel(R) Xeon(R) CPU E5-2690 0 @ 2.90GHz"},
     {"number_of_cpus": 35465},
     {"number_of_sockets": 35465},
     {"cores_per_socket": 35465},


### PR DESCRIPTION
Add the cpu model name as cpu_model to system profile as requested:
https://issues.redhat.com/browse/HBISPSC-39

Related puptoo PR:
https://github.com/RedHatInsights/insights-puptoo/pull/117