### PR TITLE
Add smart_management_enabled field to system profile

### DIFF
--- a/schemas/system_profile/v1.yaml
+++ b/schemas/system_profile/v1.yaml
@@ -344,3 +344,6 @@ $defs:
             example: "8.1"
             type: string
             maxLength: 255
+      smart_management_enabled:
+        type: boolean
+        description: Indicates whether Smart Management is enabled

--- a/tests/utils/invalids.py
+++ b/tests/utils/invalids.py
@@ -68,4 +68,5 @@ INVALID_SYSTEM_PROFILES = (
     {"yum_repos": [{"gpgcheck": "True"}]},
     {"yum_repos": [{"enabled": "False"}]},
     {"installed_packages_delta": ["x" * 513]},
+    {"smart_management_enabled": "True"},
 )

--- a/tests/utils/valids.py
+++ b/tests/utils/valids.py
@@ -65,4 +65,5 @@ VALID_SYSTEM_PROFILES = (
     {"yum_repos": [{"gpgcheck": True}]},
     {"yum_repos": [{"enabled": False}]},
     {"installed_packages_delta": ["x" * 512]},
+    {"smart_management_enabled": True},
 )


### PR DESCRIPTION
Addresses this Jira: https://issues.redhat.com/browse/RHCLOUD-11978
Adds the boolean "smart_management_enabled" field to the System Profile.
The corresponding host-inventory PR is here: https://github.com/RedHatInsights/insights-host-inventory/pull/822