### PR TITLE
Add is_marketplace boolean field to system profile

### DIFF
--- a/schemas/system_profile/v1.yaml
+++ b/schemas/system_profile/v1.yaml
@@ -335,6 +335,9 @@ $defs:
         maxLength: 10
         description: The SELinux mode provided in the config file
         example: 'permissive'
+      is_marketplace:
+        description: Indicates whether the host is part of a marketplace install from AWS, Azure, etc.
+        type: boolean
       rhsm:
         description: Object for subscription-manager details
         type: object

--- a/tests/utils/invalids.py
+++ b/tests/utils/invalids.py
@@ -65,6 +65,7 @@ INVALID_SYSTEM_PROFILES = (
     {"operating_system": {"name": 'ABCD'}},
     {"katello_agent_running": "False"},
     {"satellite_managed": "True"},
+    {"is_marketplace": "True"},
     {"yum_repos": [{"gpgcheck": "True"}]},
     {"yum_repos": [{"enabled": "False"}]},
     {"installed_packages_delta": ["x" * 513]},

--- a/tests/utils/valids.py
+++ b/tests/utils/valids.py
@@ -62,6 +62,7 @@ VALID_SYSTEM_PROFILES = (
     {"operating_system": {"name": 'RHEL'}},
     {"katello_agent_running": False},
     {"satellite_managed": True},
+    {"is_marketplace": True},
     {"yum_repos": [{"gpgcheck": True}]},
     {"yum_repos": [{"enabled": False}]},
     {"installed_packages_delta": ["x" * 512]},


### PR DESCRIPTION
Addresses this Jira: https://issues.redhat.com/browse/RHCLOUD-12582
Adds the boolean "is_marketplace" field to the system profile.
The corresponding host-inventory PR is here: https://github.com/RedHatInsights/insights-host-inventory/pull/823