### PR TITLE
Change selinux_config_file from enum to allow a string

### DIFF
--- a/schemas/system_profile/v1.yaml
+++ b/schemas/system_profile/v1.yaml
@@ -331,8 +331,7 @@ $defs:
         example: 'enforcing'
       selinux_config_file:
         type: string
-        enum: [enforcing, permissive, disabled]
-        maxLength: 10
+        maxLength: 128
         description: The SELinux mode provided in the config file
         example: 'permissive'
       is_marketplace:

--- a/tests/utils/invalids.py
+++ b/tests/utils/invalids.py
@@ -47,7 +47,7 @@ INVALID_SYSTEM_PROFILES = (
     {"sap_version": "1.00.122.04.147857563665464"},
     {"tuned_profile": "x"*257},
     {"selinux_current_mode": "random"},
-    {"selinux_config_file": "random"},
+    {"selinux_config_file": "x"*129},
     {"owner_id": "x"*12},
     {"rhc_client_id": "x"*12},
     {"rhc_client_id": "plxi13y1-99ut-3rdf-bc10-84opf904lfad"},


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/HBISPSC-38

Turns out sestatus code allows a value like `error (X)"` where X is more info about the error.
This change allows the `selinux_config_file` field to contain any string up to 128 characters.
