### PR TITLE
Update CODEOWNERS path and add codeheeler

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 * @RedHatInsights/host-based-inventory-committers
 
 # Stakeholders and HBI devs
-schemas/system_profile/* @stevehnh @jeromemarc @kahowell @beav @RedHatInsights/host-based-inventory-committers
+/schemas/system_profile/* @stevehnh @jeromemarc @kahowell @beav @codeheeler @RedHatInsights/host-based-inventory-committers


### PR DESCRIPTION
Does a couple of things:
1. Updates the System Profile spec folder path to reference the specific folder that we update (from root, not just any folder matching that pattern)
2. Adds @CodeHeeler to the list of reviewers, since she's a stakeholder

I'm not sure why Stephen Adams keeps getting added as a reviewer to every PR, but nobody else we've listed (besides HBI team) gets added. I'm hoping that fixing the path will get it to work