### PR TITLE
Add gpg_pubkey array

### DIFF
--- a/schemas/system_profile/v1.yaml
+++ b/schemas/system_profile/v1.yaml
@@ -277,17 +277,24 @@ $defs:
         type: string
         maxLength: 32
       installed_packages:
-        type: array  # technically a set, ordering is not important
+        type: array  # technically a set, ordered by RPM sorting algorithm
         items:
           description: A NEVRA string for a single installed package
           example: "krb5-libs-0:-1.16.1-23.fc29.i686"
           type: string
           maxLength: 512
       installed_packages_delta:
-        type: array  # sorted list, rest of packages not in installed_packages
+        type: array  # packages not in installed_packages, ordered by RPM sorting algorithm
         items:
           description: A NEVRA string for a single installed package
           example: "krb5-libs-0:-1.16.1-23.fc29.i686"
+          type: string
+          maxLength: 512
+      gpg_pubkeys:
+        type: array  # technically a set, ordered by RPM sorting algorithm
+        items:
+          description: A package name string of a single imported GPG pubkey
+          example: "gpg-pubkey-11111111-22222222"
           type: string
           maxLength: 512
       installed_services:

--- a/tests/utils/invalids.py
+++ b/tests/utils/invalids.py
@@ -35,6 +35,7 @@ INVALID_SYSTEM_PROFILES = (
     {"insights_egg_version": "x" * 51},
     {"captured_date": "x" * 33},
     {"installed_packages": ["x" * 513]},
+    {"gpg_pubkeys": ["x" * 513]},
     {"installed_services": ["x" * 513]},
     {"enabled_services": ["x" * 513]},
     {"sap_sids": ["XXXX"]},

--- a/tests/utils/valids.py
+++ b/tests/utils/valids.py
@@ -35,6 +35,7 @@ VALID_SYSTEM_PROFILES = (
     {"insights_egg_version": "x" * 50},
     {"captured_date": "x" * 32},
     {"installed_packages": ["x" * 512]},
+    {"gpg_pubkeys": ["x" * 512]},
     {"installed_services": ["x" * 512]},
     {"enabled_services": ["x" * 512]},
     {"sap_sids": ["H2O"]},


### PR DESCRIPTION
GPG pubkeys are stored as an array of package names with RPM sorting applied.
The sort probably has no meaning for these synthetic packages, but it makes
order consistent.

Signed-off-by: Christopher Sams <csams@redhat.com>