### PR TITLE
Fix parsing error in xjoin-search mapping updater

### DIFF
--- a/schemas/system_profile/v1.yaml
+++ b/schemas/system_profile/v1.yaml
@@ -176,7 +176,7 @@ $defs:
         example: False
         type: boolean
   SystemProfile:
-    title: system_profile
+    title: SystemProfile
     description: Representation of the system profile fields
     type: object
     properties:

--- a/schemas/system_profile/v1.yaml
+++ b/schemas/system_profile/v1.yaml
@@ -176,6 +176,7 @@ $defs:
         example: False
         type: boolean
   SystemProfile:
+    title: system_profile
     description: Representation of the system profile fields
     type: object
     properties:


### PR DESCRIPTION
Hey, small change that shouldn't efffect anything else. I run into parsing errors in the script I'm creating to automatically update the elasticsearch mapping in xjoin-search when SystemProfile doesn't have a title field. This PR simply gives it a title :)