### PR TITLE
Add ansible booleans to system profile

### DIFF
--- a/schemas/system_profile/v1.yaml
+++ b/schemas/system_profile/v1.yaml
@@ -462,3 +462,23 @@ $defs:
             maxLength: 12
             enum: ['Premium', 'Standard', 'Self-Support']
             example: 'Premium'
+      ansible:
+        description: Object containing data specific to Ansible Automation Platform
+        type: object
+        properties:
+          controller_system:
+            description: The ansible-tower or automation-controller RPM is present on the host
+            type: boolean
+            example: True
+          hub_system:
+            description: The automation-hub RPM is present on the host
+            type: boolean
+            example: False
+          catalog_worker_system:
+            description: The catalog-worker RPM is present on the host
+            type: boolean
+            example: True
+          sso_system:
+            description: Host is an ansible-sso system
+            type: boolean
+            example: False

--- a/tests/utils/invalids.py
+++ b/tests/utils/invalids.py
@@ -243,4 +243,10 @@ INVALID_SYSTEM_PROFILES = (
         "role": "bar",
         "sla": "baz",
     }},
+    {"ansible": {
+        "controller_system": "strings are invalid",
+        "hub_system": 17,
+        "catalog_worker_system": "still invalid",
+        "sso_system": 1
+    }},
 )

--- a/tests/utils/valids.py
+++ b/tests/utils/valids.py
@@ -114,4 +114,10 @@ VALID_SYSTEM_PROFILES = (
         "role": "Red Hat Enterprise Linux Compute Node",
         "sla": "Self-Support"
     }},
+    {"ansible": {
+        "controller_system": True,
+        "hub_system": False,
+        "catalog_worker_system": True,
+        "sso_system": False
+    }},
 )


### PR DESCRIPTION
Adds booleans to represent `ansible_controller_system`, `ansible_hub_system`, `ansible_catalog_worker_system`, and `ansible_sso_system`. Similar to how we handled `system_purpose`, I've combined them into an `ansible` object which has the boolean fields:

- controller_system
- hub_system
- catalog_worker_system
- sso_system