### PR TITLE
Add mssql workload object

### DIFF
--- a/schemas/system_profile/v1.yaml
+++ b/schemas/system_profile/v1.yaml
@@ -494,3 +494,12 @@ $defs:
             maxLength: 30
             pattern: '^\d+(\.\d+)+$'
             x-wildcard: true
+      mssql:
+        description: Object containing data specific to the MS SQL workload
+        type: object
+        properties:
+          version:
+            description: MSSQL version number 
+            type: string
+            example: '15.2.0'
+            x-wildcard: true

--- a/tests/utils/invalids.py
+++ b/tests/utils/invalids.py
@@ -261,4 +261,7 @@ INVALID_SYSTEM_PROFILES = (
         "catalog_worker_version": False,
         "sso_version": False,
     }},
+    {"mssql": { # Must be a string, not a number
+        "version": 15.3,
+    }},
 )

--- a/tests/utils/valids.py
+++ b/tests/utils/valids.py
@@ -120,4 +120,7 @@ VALID_SYSTEM_PROFILES = (
         "catalog_worker_version": "100.387.9846.12",
         "sso_version": "1.28.3.52641.10000513168495123"
     }},
+    {"mssql": {
+        "version": "15.3",
+    }}
 )


### PR DESCRIPTION
This PR addresses [ESSNTL-1421](https://issues.redhat.com/browse/ESSNTL-1421). 
It adds the mssql object to the System Profile, along with one field so far called "version". Even though there's only one field on this object right now, we've discussed the possibility of adding one or two additional fields to the object at a later date, so I wanted to future-proof it a bit.