### PR TITLE
Fix ipv4 address example

### DIFF
--- a/schemas/system_profile/v1.yaml
+++ b/schemas/system_profile/v1.yaml
@@ -95,7 +95,7 @@ $defs:
         type: array
         items:
           description: The ipv4 address of the system
-          example: "123.456.789.012"
+          example: "192.0.2.146"
           type: string
           format: ipv4
       ipv6_addresses:

--- a/tests/utils/invalids.py
+++ b/tests/utils/invalids.py
@@ -65,7 +65,7 @@ INVALID_SYSTEM_PROFILES = (
     {"system_memory_bytes": "35465"},
     {"system_memory_bytes": 18446744073709551617},
     {"network_interfaces": [{"mtu": 18446744073709551617}]},
-    {"network_interfaces": [{"ipv4_addresses": "123.456.789.012"}]},
+    {"network_interfaces": [{"ipv4_addresses": "192.0.2.146"}]},
     {"network_interfaces": [{"ipv6_addresses": "0123:4567:89ab:cdef:0123:4567:89ab:cdef"}]},
     {"network_interfaces": [{"mtu": "15"}]},
     {"rhsm": {"version": "x" * 300}},

--- a/tests/utils/valids.py
+++ b/tests/utils/valids.py
@@ -64,7 +64,7 @@ VALID_SYSTEM_PROFILES = (
     {"number_of_sockets": 35465},
     {"cores_per_socket": 35465},
     {"system_memory_bytes": 35465},
-    {"network_interfaces": [{"ipv4_addresses": ["123.456.789.012"]}]},
+    {"network_interfaces": [{"ipv4_addresses": ["192.0.2.146"]}]},
     {"network_interfaces": [{"ipv6_addresses": ["0123:4567:89ab:cdef:0123:4567:89ab:cdef"]}]},
     {"network_interfaces": [{"mtu": 15}]},
     {"operating_system": {"major": 10}},


### PR DESCRIPTION
"123.456.789.012" is not a valid ipv4 address. I've updated our example values to use "192.0.2.146", which _is_ valid.