### PR TITLE
Remove codeheeler from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 * @RedHatInsights/host-based-inventory-committers
 
 # Stakeholders and HBI devs
-/schemas/system_profile/* @stevehnh @jeromemarc @kahowell @beav @codeheeler @RedHatInsights/host-based-inventory-committers
+/schemas/system_profile/* @stevehnh @jeromemarc @kahowell @beav @RedHatInsights/host-based-inventory-committers


### PR DESCRIPTION
Dana is now part of the @RedHatInsights/host-based-inventory-committers group, so this removes the explicit reference in the CODEOWNERS file.