### PR TITLE
Remove 'purple' as example for greenboot_status because only green an…

### DIFF
--- a/schemas/system_profile/v1.yaml
+++ b/schemas/system_profile/v1.yaml
@@ -505,7 +505,7 @@ $defs:
         enum: [red, green]
         maxLength: 5
         description: Indicates the greenboot status of an edge device.
-        example: 'green, red, purple'
+        example: 'green, red'
       greenboot_fallback_detected:
         type: boolean
         description: Indicates whether greenboot detected a rolled back update on an edge device.


### PR DESCRIPTION
…d red are allowed

Greenboot_status can be either red or green per `enum(red, green)`.  Some how purple was included as an example.