### PR TITLE
[ci] Fix Python3.6 issue on Linux x86

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,12 +20,12 @@ jobs:
     - run: spectral lint schemas/system_profile/v1.yaml
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.6
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.6
     - name: Install dependencies

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -25,10 +25,11 @@ class SystemProfileTests(TestCase):
         for system_profile in INVALID_SYSTEM_PROFILES:
             with self.subTest(system_profile=system_profile):
                 with pytest.raises(ValidationError):
-                    CustomDraft4Validator(self.specification["$defs"]["SystemProfile"], resolver=self.resolver).validate(system_profile)
+                    CustomDraft4Validator(self.specification["$defs"]["SystemProfile"],
+                                          resolver=self.resolver).validate(system_profile)
 
     def test_system_profile_valids(self):
         for system_profile in VALID_SYSTEM_PROFILES:
             with self.subTest(system_profile=system_profile):
-                CustomDraft4Validator(self.specification["$defs"]["SystemProfile"], resolver=self.resolver).validate(system_profile)
-
+                CustomDraft4Validator(self.specification["$defs"]["SystemProfile"],
+                                      resolver=self.resolver).validate(system_profile)

--- a/tests/utils/invalids.py
+++ b/tests/utils/invalids.py
@@ -126,11 +126,11 @@ INVALID_SYSTEM_PROFILES = (
     {"network_interfaces": [{"ipv6_addresses": "0123:4567:89ab:cdef:0123:4567:89ab:cdef"}]},
     {"network_interfaces": [{"mtu": "15"}]},
     {"rhsm": {"version": "x" * 300}},
-    {"operating_system": {"name": "RHEL"}}, # Incomplete OS definition
-    {"operating_system": {"name": "RHEL", "major": 9}}, # Incomplete OS definition
-    {"operating_system": {"major": 8, "minor": 7}}, # Incomplete OS definition
-    {"operating_system": {"name": "ABCD", "major": 9, "minor": 0}}, # Invalid name    
-    {"operating_system": {"name": "RHEL", "major": "9", "minor": "0"}}, # Invalid types
+    {"operating_system": {"name": "RHEL"}},  # Incomplete OS definition
+    {"operating_system": {"name": "RHEL", "major": 9}},  # Incomplete OS definition
+    {"operating_system": {"major": 8, "minor": 7}},  # Incomplete OS definition
+    {"operating_system": {"name": "ABCD", "major": 9, "minor": 0}},  # Invalid name
+    {"operating_system": {"name": "RHEL", "major": "9", "minor": "0"}},  # Invalid types
     {"katello_agent_running": "False"},
     {"satellite_managed": "True"},
     {"is_marketplace": "True"},
@@ -302,28 +302,28 @@ INVALID_SYSTEM_PROFILES = (
         "role": "bar",
         "sla": "baz",
     }},
-    {"ansible": { # wrong data type for controller_version
+    {"ansible": {  # wrong data type for controller_version
         "controller_version": 1.0,
         "hub_version": "3.4.1",
         "catalog_worker_version": "100.387.9846.12",
         "sso_version": "1.28.3.52641.10000513168495123",
     }},
-    {"ansible": { # sso_version too long
+    {"ansible": {  # sso_version too long
         "controller_version": "1.0",
         "hub_version": "3.4.1",
         "catalog_worker_version": "100.387.9846.12",
         "sso_version": "1.4"*11,
     }},
-    {"ansible": { # don't send "existence" booleans in place of versions
+    {"ansible": {  # don't send "existence" booleans in place of versions
         "controller_version": True,
         "hub_version": False,
         "catalog_worker_version": False,
         "sso_version": False,
     }},
-    {"mssql": { # Must be a string, not a number
+    {"mssql": {  # Must be a string, not a number
         "version": 15.3,
     }},
-    {"mssql": { # Too long
+    {"mssql": {  # Too long
         "version": "x" * 35,
     }},
     {"system_update_method": "inv_method"}

--- a/tests/utils/valids.py
+++ b/tests/utils/valids.py
@@ -83,7 +83,9 @@ VALID_SYSTEM_PROFILES = (
     {"is_marketplace": True},
     {"yum_repos": [{"gpgcheck": True}]},
     {"yum_repos": [{"enabled": False}]},
-    {"yum_repos": [{"mirrorlist": "https://rhui.redhat.com/pulp/mirror/content/dist/rhel8/rhui/$releasever/$basearch/baseos/os"}]},
+    {"yum_repos": [
+        {"mirrorlist": "https://rhui.redhat.com/pulp/mirror/content/dist/rhel8/rhui/$releasever/$basearch/baseos/os"}
+    ]},
     {"installed_packages_delta": ["x" * 512]},
     {"host_type": "edge"},
     {"greenboot_status": "red"},


### PR DESCRIPTION
These patches fix the following issue:

```
Error: Version 3.6 with arch x64 not found
```

Cause: there is no available build of Python 3.6 for ubuntu-22.04

ref: [Error: Version 3.6 with arch x64 not found](https://github.com/actions/setup-python/issues/544)

And also fixes the flake8 syntax errors.

Signed-off-by: Gael Chamoulaud (Strider) <gchamoul@redhat.com>