### PR TITLE
Add test field to trigger SP validator

### DIFF
--- a/schemas/system_profile/v1.yaml
+++ b/schemas/system_profile/v1.yaml
@@ -593,3 +593,8 @@ $defs:
         maxLength: 10
         enum: [dnf, rpm-ostree, yum]
         example: "dnf, rpm-ostree, yum"
+      test_field_do_not_merge:
+        description: This field is being added to a draft PR to test the SP Validator job and should not be merged.
+        type: string
+        maxLength: 10
+        example: "donotmerge"


### PR DESCRIPTION
We need to trigger the SP Validator in the Prod environment to verify that it works with its current Kafka consumer group-id config.