### PR TITLE
Add cloud external DNS

### DIFF
--- a/schemas/system_profile/v1.yaml
+++ b/schemas/system_profile/v1.yaml
@@ -395,6 +395,15 @@ $defs:
           maxLength: 15
           example: "12.23.31.32"
           format: ipv4
+      public_dns:
+        type: array
+        x-indexed: false
+        items:
+          description: The external DNS of the system
+          type: string
+          maxLength: 100
+          example: "ec2-12-34-56-78.us-west-2.compute.amazonaws.com"
+          format: string
       yum_repos:
         type: array  # technically a set, ordering is not important
         x-indexed: false

--- a/tests/utils/invalids.py
+++ b/tests/utils/invalids.py
@@ -27,6 +27,7 @@ INVALID_SYSTEM_PROFILES = (
     {"subscription_auto_attach": ["x" * 101]},
     {"cloud_provider": ["x" * 101]},
     {"public_ipv4_addresses": ["x" * 16]},
+    {"public_dns": ["x" * 101]},
     {"yum_repos": [{"id": "x" * 257}]},
     {"yum_repos": [{"name": "x" * 1025}]},
     {"yum_repos": [{"base_url": "x" * 2049}]},

--- a/tests/utils/valids.py
+++ b/tests/utils/valids.py
@@ -35,6 +35,7 @@ VALID_SYSTEM_PROFILES = (
     {"subscription_auto_attach": "x" * 100},
     {"cloud_provider": "x" * 100},
     {"public_ipv4_addresses": ["123.123.123.123"]},
+    {"public_dns": ["x" * 100]},
     {"yum_repos": [{"id": "x" * 256}]},
     {"yum_repos": [{"name": "x" * 1024}]},
     {"yum_repos": [{"base_url": "x" * 2048}]},


### PR DESCRIPTION
Adds hyperscaler public autogenerated DNS, only available on AWS EC2.

This is a followup for https://github.com/RedHatInsights/inventory-schemas/commit/a09c33520891022af77fd3e2fcaca46a9bf95bda

https://issues.redhat.com/browse/ESSNTL-4992