### PR TITLE
RHINENG-1494 adding proposed changes to os name

### DIFF
--- a/schemas/system_profile/v1.yaml
+++ b/schemas/system_profile/v1.yaml
@@ -324,8 +324,8 @@ $defs:
             description: Name of the distro/os
             type: string
             maxLength: 6
-            enum: [RHEL, CentOS]
-            example: "RHEL, CentOS, RHEL"
+            enum: [RHEL, CentOS, CentOS Linux]
+            example: "RHEL, CentOS, CentOS Linux, RHEL"
       os_release:
         type: string
         maxLength: 100

--- a/schemas/system_profile/v1.yaml
+++ b/schemas/system_profile/v1.yaml
@@ -323,9 +323,9 @@ $defs:
           name:
             description: Name of the distro/os
             type: string
-            maxLength: 6
+            maxLength: 12
             enum: [RHEL, CentOS, CentOS Linux]
-            example: "RHEL, CentOS, CentOS Linux, RHEL"
+            example: "RHEL, CentOS, CentOS Linux"
       os_release:
         type: string
         maxLength: 100

--- a/tests/utils/valids.py
+++ b/tests/utils/valids.py
@@ -80,6 +80,7 @@ VALID_SYSTEM_PROFILES = (
     {"rhsm": {"version": "99Server"}},
     {"operating_system": {"name": "RHEL", "major": 8, "minor": 10}},
     {"operating_system": {"name": "CentOS", "major": 7, "minor": 0}},
+    {"operating_system": {"name": "CentOS Linux", "major": 7, "minor": 0}},
     {"katello_agent_running": False},
     {"satellite_managed": True},
     {"is_marketplace": True},


### PR DESCRIPTION
Currently, in the system_profile schema, under operating_system:properties:name the schema is defined for [RHEL, CentOS]. During a previous conversation it was mentioned that CentOS 7 systems need to say "CentOS Linux", and if we ever enabled CentOS Stream, that name would need added as well. With my proposed change to puptoo, systems fail to update/check in with the new functionality of the "CentOS Linux" name because the schema does not allow it.  I am proposing that we simply update that one name. 