### PR TITLE
RHIN-1077: Add threads_per_core

### DIFF
--- a/schemas/system_profile/v1.yaml
+++ b/schemas/system_profile/v1.yaml
@@ -235,10 +235,12 @@ $defs:
         minimum: 0
         maximum: 2147483647
       threads_per_core:
+        description: Number of CPU threads per CPU core. Typical values: 1, 2, 4
         type: integer
         format: int32
         minimum: 0
         maximum: 2147483647
+        example: 2
       system_memory_bytes:
         type: integer
         format: int64

--- a/schemas/system_profile/v1.yaml
+++ b/schemas/system_profile/v1.yaml
@@ -234,6 +234,11 @@ $defs:
         format: int32
         minimum: 0
         maximum: 2147483647
+      threads_per_core:
+        type: integer
+        format: int32
+        minimum: 0
+        maximum: 2147483647
       system_memory_bytes:
         type: integer
         format: int64


### PR DESCRIPTION
https://issues.redhat.com/browse/RHIN-1077

Generally speaking, this will be equal to:

```python
threads_per_core = number_of_cpus / (number_of_sockets * cores_per_socket)
```

However, given hypervisors can report inaccurate CPU topologies, this field will give us a way to indicate the real SMT ratio.

For example, a VM can be provisioned having the following apparent CPU topology:

```python
number_of_sockets = 5
number_of_cpus = 5
cores_per_socket = 1
```

This would suggest a `threads_per_core` value of `1`. However, the hypervisor could actually be a 3 core machine with an SMT ratio of 2.

Capturing `threads_per_core` separately allows us to capture these nuances, when tooling and reporters support this.