### PR TITLE
DISCOVERY-325: Add virtual_host_uuid

### DIFF
--- a/schemas/system_profile/v1.yaml
+++ b/schemas/system_profile/v1.yaml
@@ -650,3 +650,9 @@ $defs:
         maxLength: 10
         enum: [dnf, rpm-ostree, yum]
         example: "dnf, rpm-ostree, yum"
+      virtual_host_uuid:
+        description: Hypervisor host identity (subscription manager id)
+        type: string
+        pattern: '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+        maxLength: 36
+        examples: 0ddf52cb-94e3-4ada-bdf7-d424a547b671, 6996463b-c9d4-402b-ad37-8ab5556ddf88, 0c352918-fa05-4f05-996c-6c43ec0b3c5e


### PR DESCRIPTION
virtual_host_uuid field is added to reflect the hypervisor identity (subiscription_manager_id) of a system's hypervisor (which is typically collected by virt-who).

https://issues.redhat.com/browse/DISCOVERY-325