### PR TITLE
fix(RHINENG-7729): Manually resolve $refs as a workaround

### DIFF
--- a/schemas/system_profile/v1.yaml
+++ b/schemas/system_profile/v1.yaml
@@ -191,22 +191,6 @@ $defs:
         description: Whether the deployment is currently pinned
         type: boolean
         example: false
-  BootcStatusImageInfo:
-    description: Object containing image data from command bootc status
-    type: object
-    properties:
-      image:
-        description: Name of the image
-        type: string
-        example: "quay.io/centos-bootc/fedora-bootc-cloud:eln, 192.168.0.1:5000/foo/foo:latest"
-        maxLength: 128
-        x-wildcard: true
-      image_digest:
-        description: Digest of the image
-        type: string
-        example: "sha256:806d77394f96e47cf99b1233561ce970c94521244a2d8f2affa12c3261961223, sha256:92e476435ced1c148350c660b09c744717defbd300a15d33deda5b50ad6b21a0"
-        maxLength: 128
-        pattern: "^(sha256\\:)[a-fA-F0-9]{64}$"
   SystemProfile:
     title: SystemProfile
     description: Representation of the system profile fields
@@ -673,14 +657,66 @@ $defs:
         maxLength: 36
         example: 0ddf52cb-94e3-4ada-bdf7-d424a547b671, 6996463b-c9d4-402b-ad37-8ab5556ddf88, 0c352918-fa05-4f05-996c-6c43ec0b3c5e
       bootc_status:
-        description: Object containing images data from command bootc status
+        description: Object containing image data from command bootc status
         type: object
         properties:
           booted:
-            $ref: '#/$defs/BootcStatusImageInfo'
+            type: object
+            properties:
+              image:
+                description: Name of the image
+                type: string
+                example: "quay.io/centos-bootc/fedora-bootc-cloud:eln, 192.168.0.1:5000/foo/foo:latest"
+                maxLength: 128
+                x-wildcard: true
+              image_digest:
+                description: Digest of the image
+                type: string
+                example: "sha256:806d77394f96e47cf99b1233561ce970c94521244a2d8f2affa12c3261961223, sha256:92e476435ced1c148350c660b09c744717defbd300a15d33deda5b50ad6b21a0"
+                maxLength: 128
+                pattern: "^(sha256\\:)[a-fA-F0-9]{64}$"
           cachedUpdate:
-            $ref: '#/$defs/BootcStatusImageInfo'
+            type: object
+            properties:
+              image:
+                description: Name of the image
+                type: string
+                example: "quay.io/centos-bootc/fedora-bootc-cloud:eln, 192.168.0.1:5000/foo/foo:latest"
+                maxLength: 128
+                x-wildcard: true
+              image_digest:
+                description: Digest of the image
+                type: string
+                example: "sha256:806d77394f96e47cf99b1233561ce970c94521244a2d8f2affa12c3261961223, sha256:92e476435ced1c148350c660b09c744717defbd300a15d33deda5b50ad6b21a0"
+                maxLength: 128
+                pattern: "^(sha256\\:)[a-fA-F0-9]{64}$"
           rollback:
-            $ref: '#/$defs/BootcStatusImageInfo'
+            type: object
+            properties:
+              image:
+                description: Name of the image
+                type: string
+                example: "quay.io/centos-bootc/fedora-bootc-cloud:eln, 192.168.0.1:5000/foo/foo:latest"
+                maxLength: 128
+                x-wildcard: true
+              image_digest:
+                description: Digest of the image
+                type: string
+                example: "sha256:806d77394f96e47cf99b1233561ce970c94521244a2d8f2affa12c3261961223, sha256:92e476435ced1c148350c660b09c744717defbd300a15d33deda5b50ad6b21a0"
+                maxLength: 128
+                pattern: "^(sha256\\:)[a-fA-F0-9]{64}$"
           staged:
-            $ref: '#/$defs/BootcStatusImageInfo'
+            type: object
+            properties:
+              image:
+                description: Name of the image
+                type: string
+                example: "quay.io/centos-bootc/fedora-bootc-cloud:eln, 192.168.0.1:5000/foo/foo:latest"
+                maxLength: 128
+                x-wildcard: true
+              image_digest:
+                description: Digest of the image
+                type: string
+                example: "sha256:806d77394f96e47cf99b1233561ce970c94521244a2d8f2affa12c3261961223, sha256:92e476435ced1c148350c660b09c744717defbd300a15d33deda5b50ad6b21a0"
+                maxLength: 128
+                pattern: "^(sha256\\:)[a-fA-F0-9]{64}$"


### PR DESCRIPTION
This PR addresses [RHINENG-7729](https://issues.redhat.com/browse/RHINENG-7729). While trying to synchronize the change introduced with #123, we discovered that there's an issue in one of our dependencies that causes everything to break when a $ref is used outside the context of array.items.

I've opened [RHINENG-7731](https://issues.redhat.com/browse/RHINENG-7731) to address the above issue, and to remove the duplication once the issue is resolved.

Follows up on #123.