### PR TITLE
FIX: Refactor array items into def section

### DIFF
--- a/schemas/system_profile/v1.yaml
+++ b/schemas/system_profile/v1.yaml
@@ -191,6 +191,26 @@ $defs:
         description: Whether the deployment is currently pinned
         type: boolean
         example: false
+  InterSystemsRunningInstance:
+    description: The info for an InterSystems instance running on the system
+    type: object
+    properties:
+      instance_name:
+        description: The name of the instance
+        type: string
+        example: "IRIS3, PROD"
+        maxLength: 255
+      product:
+        description: The product of the instance
+        type: string
+        example: "IRIS"
+        maxLength: 64
+      version:
+        description: The version of the instance
+        type: string
+        example:  "2023.1, 2023.2"
+        maxLength: 7
+        pattern: '^\d+(\.\d+)+$'
   SystemProfile:
     title: SystemProfile
     description: Representation of the system profile fields
@@ -644,25 +664,7 @@ $defs:
           running_instances:
             type: array
             items:
-              description: The info for each running InterSystems instances in the system
-              type: object
-              properties:
-                instance_name:
-                  description: The name of the instance
-                  type: string
-                  example: "IRIS3, PROD"
-                  maxLength: 255
-                product:
-                  description: The product of the instance
-                  type: string
-                  example: "IRIS"
-                  maxLength: 64
-                version:
-                  description: The version of the instance
-                  type: string
-                  example:  "2023.1, 2023.2"
-                  maxLength: 7
-                  pattern: '^\d+(\.\d+)+$'
+              $ref: '#/$defs/InterSystemsRunningInstance'
       mssql:
         description: Object containing data specific to the MS SQL workload
         type: object


### PR DESCRIPTION
Follows up on #122. HBI's validation code ran into issues with the original structure of this object, so I refactored the array items into their own schema in the `defs` section. When formatted this way, the validation works without error.