### PR TITLE
RHINENG-15790: add facts to "workloads.rhel_ai" field

### DIFF
--- a/schemas/system_profile/v1.yaml
+++ b/schemas/system_profile/v1.yaml
@@ -963,30 +963,48 @@ $defs:
                 type: string
                 example: "v1.1.3"
                 maxLength: 16
-              amd_gpu_models:
-                description: Model name of AMD GPUs
+              gpu_models:
+                description: The list of GPU models on the host
                 type: array
                 items:
-                  description: The AMD GPU model
-                  type: string
-                  example: "Advanced Micro Devices, Inc. [AMD/ATI] Device 0c34, Advanced Micro Devices, Inc. [AMD/ATI] Radeon PRO V320"
-                  maxLength: 128
-              intel_gaudi_hpu_models:
-                description: Model name of Intel Gaudi HPUs
+                  description: Object containing data specific to a GPU model
+                  type: object
+                  properties:
+                    name:
+                      description: The name of GPU model
+                      type: string
+                      example: 'NVIDIA A100 80GB PCIe, Habana Labs Ltd. Device 1020'
+                      maxLength: 128
+                    vendor:
+                      description: The vendor of GPU model
+                      type: string
+                      example: 'Nvidia, AMD, Habana'
+                      maxLength: 32
+                    memory:
+                      description: The memory of GPU model
+                      type: string
+                      example: '24GB, 80GB'
+                      maxLength: 32
+                    count:
+                      description: The count of this specific GPU model
+                      type: integer
+                      format: int32
+                      example: 4
+                      minimum: 0
+                      maximum: 9999
+              ai_models:
+                description: The list of AI models available on the host
                 type: array
                 items:
-                  description: The Intel Gaudi HPU model
+                  description: AI model name
                   type: string
-                  example: "Habana Labs Ltd. Device 1020, Habana Labs Ltd. HL-2000 AI Training Accelerator [Gaudi]"
-                  maxLength: 128
-              nvidia_gpu_models:
-                description: Model name of Nvidia GPUs in the GPU index order
-                type: array
-                items:
-                  description: The Nvidia GPU model
-                  type: string
-                  example: "Tesla V100-PCIE-16GB"
-                  maxLength: 128
+                  example: "granite-7b-redhat-lab, granite-7b-starter"
+                  maxLength: 256
+              free_disk_storage:
+                description: The free storage available on the host
+                type: string
+                example: "698GB, 3TB"
+                maxLength: 32
           sap:
             description: Object containing data specific to the SAP workload
             type: object

--- a/tests/utils/invalids.py
+++ b/tests/utils/invalids.py
@@ -515,17 +515,38 @@ INVALID_SYSTEM_PROFILES = (
         "rhel_ai": {  # Must be a string, not a number
             "variant": "RHEL AI",
             "rhel_ai_version_id": 1.1,
-            "amd_gpu_models": ["Advanced Micro Devices, Inc. [AMD/ATI] Device 0c34"],
-            "intel_gaudi_hpu_models": ["Habana Labs Ltd. Device 1020"],
-            "nvidia_gpu_models": ["NVIDIA T1000", "Tesla V100-PCIE-16GB"]
+            "gpu_models": [{
+                "name": "NVIDIA L4",
+                "vendor": "Nvidia",
+                "memory": "24GB",
+                "count": "2"
+            },{
+                "name": "Tesla V100-PCIE-16GB",
+                "vendor": "Nvidia",
+                "memory": "16GB",
+                "count": 4
+            }],
+            "ai_models": ["granite-7b-redhat-lab", "granite-7b-starter"],
+            "free_disk_storage": "698GB"
         }
     }},
     {"workloads": {
         "rhel_ai": {  # Must be a string as array elements, not a boolean
             "variant": "RHEL AI",
             "rhel_ai_version_id": "v1.1.3",
-            "amd_gpu_models": ["Advanced Micro Devices, Inc. [AMD/ATI] Device 0c34"],
-            "nvidia_gpu_models": [True, "Tesla V100-PCIE-16GB"]
+            "gpu_models": [{
+                "name": "NVIDIA L4",
+                "vendor": "Nvidia",
+                "memory": "24GB",
+                "count": 2
+            },{
+                "name": "Tesla V100-PCIE-16GB",
+                "vendor": "Nvidia",
+                "memory": "16GB",
+                "count": 4
+            }],
+            "ai_models": [True, "granite-7b-starter"],
+            "free_disk_storage": "698GB"
         }
     }},
     {"workloads": {

--- a/tests/utils/valids.py
+++ b/tests/utils/valids.py
@@ -245,15 +245,19 @@ VALID_SYSTEM_PROFILES = (
         "rhel_ai": {
             "variant": "RHEL AI",
             "rhel_ai_version_id": "v1.1.3",
-            "amd_gpu_models": [
-                "Advanced Micro Devices, Inc. [AMD/ATI] Device 0c34",
-                "Advanced Micro Devices, Inc. [AMD/ATI] Radeon PRO V320"
-            ],
-            "intel_gaudi_hpu_models": [
-                "Habana Labs Ltd. Device 1020",
-                "Habana Labs Ltd. HL-2000 AI Training Accelerator [Gaudi]"
-            ],
-            "nvidia_gpu_models": ["NVIDIA T1000", "Tesla V100-PCIE-16GB"]
+            "gpu_models": [{
+                "name": "NVIDIA L4",
+                "vendor": "Nvidia",
+                "memory": "24GB",
+                "count": 2
+            },{
+                "name": "Tesla V100-PCIE-16GB",
+                "vendor": "Nvidia",
+                "memory": "16GB",
+                "count": 4
+            }],
+            "ai_models": ["granite-7b-redhat-lab", "granite-7b-starter"],
+            "free_disk_storage": "698GB"
         },
         "sap": {
             "sap_system": True,


### PR DESCRIPTION
- add field `workloads.rhel_ai.ai_models`
- add field `workloads.rhel_ai.free_disk_storage`
- add field `workloads.rhel_ai.gpu_models`
    - intro this new field to better describe the gpu_models info across diff vendors with attributes:
       - `name`
       - `vendor`
       - `memory`
       - `count` 
    - and let it deprecate the recently added fields: (via https://github.com/RedHatInsights/inventory-schemas/pull/148)
        - `nvidia_gpu_models`
        - `amd_gpu_models`
        - `intel_gaudi_hpu_models`
    - Hope these `workloads.rhel_ai.*_gpu_models` fields are not referred by services except reporter puptoo. 

More details in RHINENG-15790