### PR TITLE
RHINENG-18525: drop the enum restriction for "system_purpose"

### DIFF
--- a/schemas/system_profile/v1.yaml
+++ b/schemas/system_profile/v1.yaml
@@ -609,20 +609,17 @@ $defs:
           usage:
             description: The intended usage of the system
             type: string
-            maxLength: 17
-            enum: ['Production', 'Development/Test', 'Disaster Recovery']
+            maxLength: 128
             example: 'Production, Development/Test, Disaster Recovery'
           role:
             description: The intended role of the system
             type: string
-            maxLength: 37
-            enum: ['Red Hat Enterprise Linux Server', 'Red Hat Enterprise Linux Workstation', 'Red Hat Enterprise Linux Compute Node']
+            maxLength: 128
             example: 'Red Hat Enterprise Linux Server, Red Hat Enterprise Linux Workstation, Red Hat Enterprise Linux Compute Node'
           sla:
             description: The intended SLA of the system
             type: string
-            maxLength: 12
-            enum: ['Premium', 'Standard', 'Self-Support']
+            maxLength: 128
             example: 'Premium, Standard, Self-Support'
       ansible:
         description: Object containing data specific to Ansible Automation Platform

--- a/tests/utils/invalids.py
+++ b/tests/utils/invalids.py
@@ -311,7 +311,7 @@ INVALID_SYSTEM_PROFILES = (
     }},
     {"system_purpose": {
         "usage": "foo",
-        "role": "bar",
+        "role": "Red Hat Enterprise Linux Server for HPC Compute Node, Self-support (Physical or Virtual Node) - and some absurd long fake string suffix",
         "sla": "baz",
     }},
     {"ansible": {  # wrong data type for controller_version


### PR DESCRIPTION
To align with the Puptoo "system_purpose" fact populating: https://github.com/RedHatInsights/insights-puptoo/pull/461

More details for the schema update reason in RHINENG-18525 